### PR TITLE
Fix failing tests due to mismatch of number formats.

### DIFF
--- a/src/test/java/org/fest/assertions/DoubleAssert_isEqualTo_withDelta_Test.java
+++ b/src/test/java/org/fest/assertions/DoubleAssert_isEqualTo_withDelta_Test.java
@@ -44,13 +44,13 @@ public class DoubleAssert_isEqualTo_withDelta_Test {
 
   @Test
   public void should_fail_if_actual_and_expected_are_not_equal() {
-    thrown.expect(AssertionError.class, "expected:<8.888> but was:<8.688> using delta:<0.0090>");
+    thrown.expect(AssertionError.class, "expected:<8.888> but was:<8.688> using delta:<0.009>");
     new DoubleAssert(8.688).isEqualTo(8.888, delta(0.009));
   }
 
   @Test
   public void should_fail_and_display_description_if_actual_and_expected_are_not_equal() {
-    thrown.expect(AssertionError.class, "[A Test] expected:<8.888> but was:<8.688> using delta:<0.0090>");
+    thrown.expect(AssertionError.class, "[A Test] expected:<8.888> but was:<8.688> using delta:<0.009>");
     new DoubleAssert(8.688).as("A Test").isEqualTo(8.888, delta(0.009));
   }
 

--- a/src/test/java/org/fest/assertions/DoubleAssert_isEqualTo_withDoubleAndDelta_Test.java
+++ b/src/test/java/org/fest/assertions/DoubleAssert_isEqualTo_withDoubleAndDelta_Test.java
@@ -43,13 +43,13 @@ public class DoubleAssert_isEqualTo_withDoubleAndDelta_Test {
 
   @Test
   public void should_fail_if_actual_and_expected_are_not_equal() {
-    thrown.expect(AssertionError.class, "expected:<8.888> but was:<8.688> using delta:<0.0090>");
+    thrown.expect(AssertionError.class, "expected:<8.888> but was:<8.688> using delta:<0.009>");
     new DoubleAssert(8.688).isEqualTo(new Double(8.888), delta(0.009));
   }
 
   @Test
   public void should_fail_and_display_description_if_actual_and_expected_are_not_equal() {
-    thrown.expect(AssertionError.class, "[A Test] expected:<8.888> but was:<8.688> using delta:<0.0090>");
+    thrown.expect(AssertionError.class, "[A Test] expected:<8.888> but was:<8.688> using delta:<0.009>");
     new DoubleAssert(8.688).as("A Test").isEqualTo(new Double(8.888), delta(0.009));
   }
 

--- a/src/test/java/org/fest/assertions/FloatAssert_isEqualTo_withDelta_Test.java
+++ b/src/test/java/org/fest/assertions/FloatAssert_isEqualTo_withDelta_Test.java
@@ -44,13 +44,13 @@ public class FloatAssert_isEqualTo_withDelta_Test {
 
   @Test
   public void should_fail_if_actual_and_expected_are_not_equal() {
-    thrown.expect(AssertionError.class, "expected:<8.888f> but was:<8.688f> using delta:<0.0090f>");
+    thrown.expect(AssertionError.class, "expected:<8.888f> but was:<8.688f> using delta:<0.009f>");
     new FloatAssert(8.688f).isEqualTo(8.888f, delta(0.009f));
   }
 
   @Test
   public void should_fail_and_display_description_if_actual_and_expected_are_not_equal() {
-    thrown.expect(AssertionError.class, "[A Test] expected:<8.888f> but was:<8.688f> using delta:<0.0090f>");
+    thrown.expect(AssertionError.class, "[A Test] expected:<8.888f> but was:<8.688f> using delta:<0.009f>");
     new FloatAssert(8.688f).as("A Test").isEqualTo(8.888f, delta(0.009f));
   }
 

--- a/src/test/java/org/fest/assertions/FloatAssert_isEqualTo_withFloatAndDelta_Test.java
+++ b/src/test/java/org/fest/assertions/FloatAssert_isEqualTo_withFloatAndDelta_Test.java
@@ -43,13 +43,13 @@ public class FloatAssert_isEqualTo_withFloatAndDelta_Test {
 
   @Test
   public void should_fail_if_actual_and_expected_are_not_equal() {
-    thrown.expect(AssertionError.class, "expected:<8.888f> but was:<8.688f> using delta:<0.0090f>");
+    thrown.expect(AssertionError.class, "expected:<8.888f> but was:<8.688f> using delta:<0.009f>");
     new FloatAssert(8.688f).isEqualTo(new Float(8.888), delta(0.009));
   }
 
   @Test
   public void should_fail_and_display_description_if_actual_and_expected_are_not_equal() {
-    thrown.expect(AssertionError.class, "[A Test] expected:<8.888f> but was:<8.688f> using delta:<0.0090f>");
+    thrown.expect(AssertionError.class, "[A Test] expected:<8.888f> but was:<8.688f> using delta:<0.009f>");
     new FloatAssert(8.688f).as("A Test").isEqualTo(new Float(8.888), delta(0.009));
   }
 


### PR DESCRIPTION
Tests were failing due to a difference in the expected number format. Made tests expectations aligned with actual behaviour. All tests in this project now pass.
